### PR TITLE
feat(api): Expose Markdown Editor API in Angular Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Covalent-Code-Editor is a Text and Code Editor built on Covalent, Monaco Editor and Angular Material
+## Covalent-Text-Editor is a Text and Code Editor built on Covalent, Monaco Editor and Angular Material
 
 [![Build Status](https://travis-ci.org/Teradata/covalent.svg?branch=develop)](https://travis-ci.org/Teradata/covalent-text-editor)
 [![npm version](https://badge.fury.io/js/%40covalent%2Ftext-editor.svg)](https://badge.fury.io/js/%40covalent%2Ftext-editor)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Covalent Github Repo: https://github.com/Teradata/covalent
 Covalent Electron Github Repo: https://github.com/Teradata/covalent-electron
 
 SimpleMDE Repo: https://github.com/sparksuite/simplemde-markdown-editor
+
 ---
 
 ## Information

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,7 @@
 | `isSideBySideActive` | `function()` | Is the Side By Side Active. Returns boolean
 | `isFullscreenActive` | `function()` | Is Full Screen Active. Returns boolean
 | `clearAutosavedValue` | `function()` | Clears Auto Saved Value. Returns void
-| `toTextArea` | `function()` | Reverts to the initial textarea. Returns void
+| `toTextArea` | `function()` | Reverts to the Initial textarea. Returns void
 
 ### Usage
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,12 +23,12 @@
 Example for HTML usage:
 
 ```html
-<td-text-editor [value]="Some Text" options="opts"></td-text-editor>
+<td-text-editor [value]="Some Text" options="options"></td-text-editor>
 ```
 
 ```typescript
 class MyComponent {
-  opts: any = {
+  options: any = {
     lineWrapping: true,
     toolbar: false,
     ...

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,7 +23,7 @@
 Example for HTML usage:
 
 ```html
-<td-text-editor [value]="Some Text" options="options"></td-text-editor>
+<td-text-editor [value]="Some Text" [options]="options"></td-text-editor>
 ```
 
 ```typescript

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,29 +4,34 @@
 
 ## API Summary
 
-### Events
-
-#### The <td-text-editor> component has 0 events:
-
-| Name | Description |
-| --- | --- |
-
-
 ### Properties
 
 #### The <td-code-editor> component has 0 properties:
 
 | Name | Type | Description |
 | --- | --- | --- |
-
+| `value?` | `string` | Value of Text in Editor
+| `options?` | `object` | Options Object of valid Configurations listed here: <a href="https://github.com/sparksuite/simplemde-markdown-editor#configuration">https://github.com/sparksuite/simplemde-markdown-editor#configuration</a>
+| `isPreviewActive` | `function()` | Is the Preview Active. Returns boolean
+| `isSideBySideActive` | `function()` | Is the Side By Side Active. Returns boolean
+| `isFullscreenActive` | `function()` | Is Full Screen Active. Returns boolean
+| `clearAutosavedValue` | `function()` | Clears Auto Saved Value. Returns void
+| `toTextArea` | `function()` | Reverts to the initial textarea. Returns void
 
 ### Usage
 
 Example for HTML usage:
 
 ```html
-<td-text-editor>
-</td-text-editor>
+<td-text-editor [value]="Some Text" options="opts"></td-text-editor>
 ```
 
+```typescript
+class MyComponent {
+  opts: any = {
+    lineWrapping: true,
+    toolbar: false,
+    ...
+  };
+}
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,12 +1,12 @@
 # td-text-editor
 
-`td-code-editor` element generates a simplemde markdown editor
+`td-text-editor` element generates a simplemde markdown editor
 
 ## API Summary
 
 ### Properties
 
-#### The <td-code-editor> component has 0 properties:
+#### The <td-text-editor> component has 0 properties:
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,7 +6,7 @@ npm install @covalent/text-editor
 ```
 * Add the following tag to html file
 ```html
-<td-text-editor [value]="Some Text" options="options"></td-text-editor>
+<td-text-editor [value]="Some Text" [options]="options"></td-text-editor>
 ```
 * Fill in options with any options listed here: 
   * <a href="https://github.com/sparksuite/simplemde-markdown-editor#configuration">https://github.com/sparksuite/simplemde-markdown-editor#configuration</a>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,13 +6,13 @@ npm install @covalent/text-editor
 ```
 * Add the following tag to html file
 ```html
-<td-text-editor [value]="Some Text" options="opts"></td-text-editor>
+<td-text-editor [value]="Some Text" options="options"></td-text-editor>
 ```
 * Fill in options with any options listed here: 
   * <a href="https://github.com/sparksuite/simplemde-markdown-editor#configuration">https://github.com/sparksuite/simplemde-markdown-editor#configuration</a>
 ```typescript
 class MyComponent {
-  opts: any = {
+  options: any = {
     lineWrapping: true,
     toolbar: false,
     ...

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,7 +6,18 @@ npm install @covalent/text-editor
 ```
 * Add the following tag to html file
 ```html
-<td-text-editor></td-text-editor>
+<td-text-editor [value]="Some Text" options="opts"></td-text-editor>
+```
+* Fill in options with any options listed here: 
+  * <a href="https://github.com/sparksuite/simplemde-markdown-editor#configuration">https://github.com/sparksuite/simplemde-markdown-editor#configuration</a>
+```typescript
+class MyComponent {
+  opts: any = {
+    lineWrapping: true,
+    toolbar: false,
+    ...
+  };
+}
 ```
 * Import the covalent-editor component into app.module.ts
 ```typescript

--- a/src/platform/text-editor/text-editor.component.spec.ts
+++ b/src/platform/text-editor/text-editor.component.spec.ts
@@ -15,6 +15,8 @@ describe('Component: TextEditor', () => {
       declarations: [
         TdTextEditorComponent,
         TestTextEditorComponent,
+        TestTextEditorResetComponent,
+        TestTextEditorOptionsComponent,
       ],
       imports: [
       ],
@@ -38,6 +40,67 @@ describe('Component: TextEditor', () => {
     })();
   });
 
+  it('should initialize the markdown editor with no toolbar options', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestTextEditorOptionsComponent);
+      let component: TestTextEditorOptionsComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          let element: HTMLElement = fixture.nativeElement;
+          expect(element.querySelectorAll('.editor-toolbar')).toBeTruthy();
+          done();
+        });
+      });
+    })();
+  });
+
+  it('should test isPreviewActive', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestTextEditorOptionsComponent);
+      let component: TestTextEditorOptionsComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(component.editor1.isFullscreenActive()).toBe(false);
+          done();
+        });
+      });
+    })();
+  });
+
+  it('should test isSideBySideActive', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestTextEditorOptionsComponent);
+      let component: TestTextEditorOptionsComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(component.editor1.isSideBySideActive()).toBe(false);
+          done();
+        });
+      });
+    })();
+  });
+
+  it('should test isFullscreenActive', (done: DoneFn) => {
+    inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TestTextEditorOptionsComponent);
+      let component: TestTextEditorOptionsComponent = fixture.debugElement.componentInstance;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(component.editor1.isFullscreenActive()).toBe(false);
+          done();
+        });
+      });
+    })();
+  });
+
 });
 
 @Component({
@@ -47,5 +110,28 @@ describe('Component: TextEditor', () => {
     </div>`,
 })
 class TestTextEditorComponent {
+  @ViewChild('editor1') editor1: TdTextEditorComponent;
+}
+
+@Component({
+  template: `
+    <div>
+      <td-text-editor #editor1 [value]="Something"></td-text-editor>  
+    </div>`,
+})
+class TestTextEditorResetComponent {
+  @ViewChild('editor1') editor1: TdTextEditorComponent;
+}
+
+@Component({
+  template: `
+    <div>
+      <td-text-editor #editor1 [options]="opts"></td-text-editor>  
+    </div>`,
+})
+class TestTextEditorOptionsComponent {
+  opts: any = {
+    toolbar: false,
+  };
   @ViewChild('editor1') editor1: TdTextEditorComponent;
 }

--- a/src/platform/text-editor/text-editor.component.ts
+++ b/src/platform/text-editor/text-editor.component.ts
@@ -28,6 +28,7 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
   private _fromEditor: boolean = false;
 
   @ViewChild('simplemde') textarea: ElementRef;
+  @Input() options: any = {};
 
   /**
    * Set if using Electron mode when object is created
@@ -74,11 +75,34 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
   }
 
   ngAfterViewInit(): void {
-    this._simpleMDE = new SimpleMDE({ element: this.elementRef.nativeElement.value });
+    this.options.element = this.elementRef.nativeElement.value;
+    this._simpleMDE = new SimpleMDE(this.options);
     this._simpleMDE.value(this.value);
     this._simpleMDE.codemirror.on('change', () => {
       this._fromEditor = true;
       this.writeValue(this._simpleMDE.value());
     });
+  }
+
+  /* Wrapped function provided by SimpleMDE */
+
+  isPreviewActive(): boolean {
+    return this._simpleMDE.isPreviewActive();
+  }
+
+  isSideBySideActive(): boolean {
+    return this._simpleMDE.isSideBySideActive();
+  }
+
+  isFullscreenActive(): boolean {
+    return this._simpleMDE.isFullscreenActive();
+  }
+
+  clearAutosavedValue(): void {
+    this._simpleMDE.clearAutosavedValue();
+  }
+
+  toTextArea(): void {
+    this._simpleMDE.toTextArea();
   }
 }


### PR DESCRIPTION
## Description
Can't use styles attribute on AOT, need to inject the css

### Test Steps
- [ ] Checkout branch
- [ ] npm install
- [ ] npm run build
- [ ] cd deploy/platform/text-editor
- [ ] npm pack (prints out a tgz file created)
- [ ] pwd (prints out your < path > you are at)
- [ ] Go to Covalent repo
- [ ] rm -rf node_modules/`@covalent`/text-editor
- [ ] npm install < path > / < tgz file created >
- [ ] ng serve --aot
- [ ] In browser go to: http://localhost:4200/#/components/text-editor
- [ ] See Markdown Editor running
- [ ] Use some of the functionality and see works

#### Screenshots
![screen shot 2017-08-04 at 2 08 53 pm](https://user-images.githubusercontent.com/10502797/28987051-86cd5346-791e-11e7-8a0f-4331e3f64ead.png)
