### PR TITLE
feat(api): Expose SimpleMDE Functions and Run in Forms

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -35,5 +35,37 @@ class MyComponent {
   };
 }
 ```
+---
+
+Example for SimpleMDE Functions usage:
+
+Any other SimpleMDE Functions can be used that are listed here:
+<a href="https://github.com/sparksuite/simplemde-markdown-editor#toolbar-icons">https://github.com/sparksuite/simplemde-markdown-editor#toolbar-icons</a>
+
+For example to use the TogglePreview to show or hide the markdown when the component loads:
+
+```html
+<td-text-editor [value]="Some Text" [options]="options" #textEditor></td-text-editor>
+```
+
+```typescript
+import { TdTextEditorComponent } from '@covalent/text-editor';
+
+...
+
+class MyComponent {
+  @ViewChild('textEditor') private _textEditor: TdTextEditorComponent;
+
+  options: any = {
+    lineWrapping: true,
+    toolbar: false,
+    ...
+  };
+
+  ngAfterViewInit(): void {
+    this._textEditor.togglePreview();
+  }
+}
+```
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,6 +17,7 @@
 | `isFullscreenActive` | `function()` | Is Full Screen Active. Returns boolean
 | `clearAutosavedValue` | `function()` | Clears Auto Saved Value. Returns void
 | `toTextArea` | `function()` | Reverts to the Initial textarea. Returns void
+| `simpleMDE` | `function()` | Getter function for the underlying simpleMDE Object. Returns SimpleMDE
 
 ### Usage
 

--- a/src/platform/text-editor/text-editor.component.ts
+++ b/src/platform/text-editor/text-editor.component.ts
@@ -61,6 +61,10 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
       return this._value;
   }
 
+  get simpleMDE(): any {
+    return this._simpleMDE;
+  }
+
   /**
    * Implemented as part of ControlValueAccessor.
    */

--- a/src/platform/text-editor/text-editor.component.ts
+++ b/src/platform/text-editor/text-editor.component.ts
@@ -80,7 +80,7 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
       styleElement.innerHTML = <string>this._domSanitizer.bypassSecurityTrustHtml(String(SimpleMDECss));
       this._document.head.appendChild(styleElement);
     }
-    this.options.element = this._elementRef.nativeElement.value;
+    this.options.element = this.textarea.nativeElement;
     this._simpleMDE = new SimpleMDE(this.options);
     this._simpleMDE.value(this.value);
     this._simpleMDE.codemirror.on('change', () => {
@@ -109,5 +109,85 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
 
   toTextArea(): void {
     this._simpleMDE.toTextArea();
+  }
+
+  toggleBold(): void {
+    this._simpleMDE.toggleBold();
+  }
+
+  toggleItalic(): void {
+    this._simpleMDE.toggleItalic();
+  }
+
+  toggleStrikethrough(): void {
+    this._simpleMDE.toggleStrikethrough();
+  }
+
+  toggleHeadingSmaller(): void {
+    this._simpleMDE.toggleHeadingSmaller();
+  }
+
+  toggleHeadingBigger(): void {
+    this._simpleMDE.toggleHeadingBigger();
+  }
+
+  toggleHeading1(): void {
+    this._simpleMDE.toggleHeading1();
+  }
+
+  toggleHeading2(): void {
+    this._simpleMDE.toggleHeading2();
+  }
+
+  toggleHeading3(): void {
+    this._simpleMDE.toggleHeading3();
+  }
+
+  toggleCodeBlock(): void {
+    this._simpleMDE.toggleCodeBlock();
+  }
+
+  toggleBlockquote(): void {
+    this._simpleMDE.toggleBlockquote();
+  }
+
+  toggleUnorderedList(): void {
+    this._simpleMDE.toggleUnorderedList();
+  }
+
+  toggleOrderedList(): void {
+    this._simpleMDE.toggleOrderedList();
+  }
+
+  cleanBlock(): void {
+    this._simpleMDE.cleanBlock();
+  }
+
+  drawLink(): void {
+    this._simpleMDE.drawLink();
+  }
+
+  drawImage(): void {
+    this._simpleMDE.drawImage();
+  }
+
+  drawTable(): void {
+    this._simpleMDE.drawTable();
+  }
+
+  drawHorizontalRule(): void {
+    this._simpleMDE.drawHorizontalRule();
+  }
+
+  togglePreview(): void {
+    this._simpleMDE.togglePreview();
+  }
+
+  toggleSideBySide(): void {
+    this._simpleMDE.toggleSideBySide();
+  }
+
+  toggleFullScreen(): void {
+    this._simpleMDE.toggleFullScreen();
   }
 }


### PR DESCRIPTION
## Description
Expose rest of SimpleMDE Functions and fix component working inside a form

### Test Steps
- [ ] Checkout branch
- [ ] npm install
- [ ] npm run build
- [ ] cd deploy/platform/text-editor
- [ ] npm pack (prints out a tgz file created)
- [ ] pwd (prints out your < path > you are at)
- [ ] Go to Covalent repo
- [ ] rm -rf node_modules/`@covalent`/text-editor
- [ ] npm install < path > / < tgz file created >
- [ ] edit the demo for code-editor.component.html and add the following:
```html
   <form #appInfoForm="ngForm" novalidate>
       <td-text-editor #textEditor flex-gt-md [(ngModel)]="appCopy.description" name="description"></td-text-editor>
   </form>
```
- [ ] edit the demo for code-editor.component.ts and add the following:
```typescript
   @ViewChild('textEditor') private _textEditor: TdTextEditorComponent;

...

ngAfterViewInit(): void {
    this._textEditor.togglePreview();
```
- [ ] edit the demo for components.module.ts and add the following:
```javascript
    import { CovalentTextEditorModule } from '../../../../node_modules/@covalent/text-editor';
```
under imports add:
```javascript
CovalentTextEditorModule
```
- [ ] ng serve
- [ ] In browser go to: http://localhost:4200/#/components/code-editor
- [ ] See Markdown Editor running in form
- [ ] See Preview Mode is on by default

#### Screenshots
![screen shot 2017-08-28 at 5 03 49 pm](https://user-images.githubusercontent.com/10502797/29798620-ea314e04-8c12-11e7-965a-6bdcfabb0043.png)
