### PR TITLE
feat(ng-packagr): Add Support for ng-packagr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/text-editor",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "private": false,
   "description": "Covalent text and markdown editor component for Angular based on SimpleMDE",
   "keywords": [
@@ -97,6 +97,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "merge2": "1.0.2",
+    "ng-packagr": "2.0.0",
     "node-sass": "3.8.0",
     "protractor": "~5.1.0",
     "require-dir": "0.3.2",

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -1,36 +1,4 @@
-#!/bin/bash
-
-set -o errexit
-
-# Clear deploy/ so that we guarantee there are no stale artifacts.
-echo "Cleaning deploy/"
+echo 'Clean up'
 rm -rf ./deploy
 
-# Perform a build.
-gulp build
-echo "SASS compiled..."
-
-# Prepare for aot
-gulp prepare-aot
-echo "Preparing files for AoT build"
-
-# AoT compilation
-npm run aot
-echo "Compiled TS and generated *.metadata.json files..."
-
-# copy README.md into deploy
-cp -rf README.md deploy/platform/text-editor/
-
-# Clean source .ts files
-cd deploy/
-find . -name "*.ts" ! -name "*.d.ts" -type f -delete
-cd ..
-echo "Remove source .ts files so they arent published"
-
-# Inline the css and html into the component files.
-gulp inline-resource-files
-echo "Resources inlined..."
-
-# Bundle
-gulp rollup-code
-echo "Bundled..."
+./node_modules/.bin/ng-packagr -p ./src/platform/text-editor/ng-package.js

--- a/src/platform/ng-package-common.js
+++ b/src/platform/ng-package-common.js
@@ -1,0 +1,9 @@
+module.exports =
+{
+  "lib": {
+    "entryFile": "index.ts",
+    "umdModuleIds": {
+      "@covalent/text-editor": "covalent.text-editor"
+    }
+  }
+};

--- a/src/platform/text-editor/index.ts
+++ b/src/platform/text-editor/index.ts
@@ -1,2 +1,1 @@
-export { TdTextEditorComponent } from './text-editor.component';
-export { CovalentTextEditorModule } from './text-editor.module';
+export * from './public-api';

--- a/src/platform/text-editor/ng-package.js
+++ b/src/platform/text-editor/ng-package.js
@@ -1,0 +1,3 @@
+let ngPackageSettings = require('../ng-package-common.js');
+ngPackageSettings["dest"] = "../../../deploy/platform/text-editor"
+module.exports = ngPackageSettings;

--- a/src/platform/text-editor/package.json
+++ b/src/platform/text-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/text-editor",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "private": false,
   "description": "Covalent text and markdown editor component for Angular based on SimpleMDE",
   "main": "./text-editor.umd.js",

--- a/src/platform/text-editor/public-api.ts
+++ b/src/platform/text-editor/public-api.ts
@@ -1,0 +1,2 @@
+export { TdTextEditorComponent } from './text-editor.component';
+export { CovalentTextEditorModule } from './text-editor.module';

--- a/src/platform/text-editor/tsconfig.json
+++ b/src/platform/text-editor/tsconfig.json
@@ -1,0 +1,16 @@
+// Configuration for IDEs only.
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@covalent/text-editor/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "../node_modules/@types"
     ],
     "paths": {
-      "@covalent/core/*": ["./platform/test-editor/*"]
+      "@covalent/text-editor/*": ["./platform/text-editor/*"]
     },
     "noUnusedParameters": false,
     "noUnusedLocals": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     "typeRoots": [
       "../node_modules/@types"
     ],
+    "paths": {
+      "@covalent/core/*": ["./platform/test-editor/*"]
+    },
     "noUnusedParameters": false,
     "noUnusedLocals": false,
     "allowUnreachableCode": false,


### PR DESCRIPTION
## Description
Add Support for ng-packagr

### Test Steps
- [ ] Checkout branch
- [ ] npm install
- [ ] npm run build
- [ ] cd deploy/platform/text-editor
- [ ] npm pack (prints out a tgz file created)
- [ ] pwd (prints out your < path > you are at)
- [ ] Go to Covalent repo
- [ ] rm -rf node_modules/`@covalent`/text-editor
- [ ] npm install < path > / < tgz file created >
- [ ] ng serve --aot
- [ ] In browser go to: http://localhost:4200/#/components/text-editor
- [ ] See Markdown Editor running
- [ ] Use some of the functionality and see works

#### Test Steps on every PR
- [ ] `npm run test` passes
- [ ] `ng lint` passes