### PR TITLE
build(covalent-text-ediitor): Use ng cli instead of ng-packagr

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -89,6 +89,20 @@
         }
       }
     },
+    "covalent-text-editor": {
+      "root": "src",
+      "sourceRoot": "src",
+      "projectType": "library",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-ng-packagr:build",
+          "options": {
+            "project": "src/platform/text-editor/ng-package.js"
+          }
+        }
+      }
+    }
   },
   "defaultProject": "covalent",
   "schematics": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "0.11.2",
+    "@angular-devkit/build-ng-packagr": "^0.11.3",
     "@angular/cli": "^7.1.2",
     "@angular/compiler-cli": "^7.1.2",
     "@types/hammerjs": "^2.0.30",

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -1,4 +1,4 @@
 echo 'Clean up'
 rm -rf ./deploy
 
-./node_modules/.bin/ng-packagr -p ./src/platform/text-editor/ng-package.js
+./node_modules/@angular/cli/bin/ng build covalent-text-editor


### PR DESCRIPTION
## Description

Use ng cli instead of ng-packagr
Fixes #22 

#### Test Steps
- [ ] `npm install`
- [ ] `npm run build`
- [ ] Check it builds correctly.
