### PR TITLE
fix(): Specify version for easymde in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "Julie Knowles <julie.knowles@teradata.com>"
   ],
   "dependencies": {
-    "easymde": "undefined"
+    "easymde": "^2.9.0"
   },
   "peerDependencies": {
     "@angular/common": "^7.0.0 || ^8.0.0 || ^9.0.0",


### PR DESCRIPTION
The package couldn't be installed via npm without a version of easymde specified

You would get the following error: `no matching version found for easymde@undefined.`